### PR TITLE
A: docs.aws.amazon.com: Remove "Agent Setup" button and "Docs AI" search results tab

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -301,16 +301,16 @@ www.asus.com###brandAssistant-root
 ! -- https://docs.aws.amazon.com/
 ! "Docs AI" button when search bar is focused
 docs.aws.amazon.com##button[aria-label="Search with Docs AI"]
-! "Docs AI" search results tab
-docs.aws.amazon.com##button[data-testid="ai"]
 ! Remove purple glow from search bar
 docs.aws.amazon.com##div:has(> [data-testid="agentic-search-trigger"]):style(background: #bbb !important)
-! "Agent Setup" button
-docs.aws.amazon.com##button[data-testid="agent-toolkit-setup-button"]
 
 ! -- https://docs.aws.amazon.com/search/doc-search.html?searchQuery=test
 ! "Docs AI" tab on search results page
-docs.aws.amazon.com##.awsui_tabs-tab_14rmt_1cc6a_216:has([data-testid="ai"])
+docs.aws.amazon.com##[class^="awsui_tabs-tab_14rmt_"]:has([data-testid="ai"])
+
+! -- https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html
+! "Agent Setup" button
+docs.aws.amazon.com##[data-testid="agent-toolkit-setup-button"]
 
 ! =========
 ! == B&Q ==

--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -301,6 +301,8 @@ www.asus.com###brandAssistant-root
 ! -- https://docs.aws.amazon.com/
 ! "Docs AI" button when search bar is focused
 docs.aws.amazon.com##button[aria-label="Search with Docs AI"]
+! "Docs AI" search results tab
+docs.aws.amazon.com##button[data-testid="ai"]
 ! Remove purple glow from search bar
 docs.aws.amazon.com##div:has(> [data-testid="agentic-search-trigger"]):style(background: #bbb !important)
 ! "Agent Setup" button

--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -303,6 +303,8 @@ www.asus.com###brandAssistant-root
 docs.aws.amazon.com##button[aria-label="Search with Docs AI"]
 ! Remove purple glow from search bar
 docs.aws.amazon.com##div:has(> [data-testid="agentic-search-trigger"]):style(background: #bbb !important)
+! "Agent Setup" button
+docs.aws.amazon.com##button[data-testid="agent-toolkit-setup-button"]
 
 ! -- https://docs.aws.amazon.com/search/doc-search.html?searchQuery=test
 ! "Docs AI" tab on search results page


### PR DESCRIPTION
In various AWS user guide, this prompt nudge is presented:

<img width="814" height="382" alt="image" src="https://github.com/user-attachments/assets/2f7f842d-0b49-4736-8b1a-5805b78e2c73" />

Also, to accompany the `aria-label="Search with Docs AI"` rule we already have, the other addition also targets the resulting tab that appears even with "AI" search isn't used:

<img width="385" height="214" alt="image" src="https://github.com/user-attachments/assets/eb34f6e8-10f8-43bc-892a-f8e0d655a1ac" />