### PR TITLE
A: eastherts.gov.uk: Floating chatbot popup

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1152,6 +1152,13 @@ www.dummies.com###engage-ai
 ! Chatbot
 support-qa.eplus.jp##iframe[title="AI Chat Support"]
 
+! =================================
+! == East Herts District Council ==
+! =================================
+! -- https://www.eastherts.gov.uk/
+! Floating chatbot popup
+www.eastherts.gov.uk###chat_content
+
 ! ==========
 ! == eBay ==
 ! ==========

--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -1157,7 +1157,7 @@ support-qa.eplus.jp##iframe[title="AI Chat Support"]
 ! =================================
 ! -- https://www.eastherts.gov.uk/
 ! Floating chatbot popup
-www.eastherts.gov.uk###chat_content
+www.eastherts.gov.uk###block-eastherts-chatbotebiai
 
 ! ==========
 ! == eBay ==


### PR DESCRIPTION
Filter to remove this floating chatbot popup on eastherts.gov.uk.
<img width="407" height="620" alt="image" src="https://github.com/user-attachments/assets/2c1c4fa1-0ede-4467-b6da-ca3f73ece63e" />
