### PR TITLE
A: code.org

### DIFF
--- a/GenAI-Blocklist.txt
+++ b/GenAI-Blocklist.txt
@@ -744,6 +744,43 @@ platform.claude.com###aiSearchResults__Item-__ask_ai__
 ! Search bar - Toggle AI mode
 platform.claude.com##.ikp-ai-search-input-group > [data-part="view_toggle"]
 
+! ==============
+! == Code.org ==
+! ==============
+! -- https://code.org/
+! "Students already use AI. They should understand it too." widget
+code.org##.contentful-container.cf-db7dcd3b13272e708a9d11a90cf3ae89
+!"Code.org has become CodeAI" banner
+code.org##.mui-ralfbg.MuiBox-root.section-background-greenMid.section-root
+! "New curriculum for a new standard" widget
+code.org##.contentful-container.cf-efb90484109697b4570e6a3f540878d1
+! "Hour of AI" hotbar button
+code.org##a.mui-xu7y1n.MuiButton-colorPrimary.MuiButton-textSizeMedium.MuiButton-sizeMedium.MuiButton-textPrimary.MuiButton-text.MuiButton-root.MuiButtonBase-root:nth-of-type(1)
+! "The Hour of AI makes teaching AI literacy easy, engaging, and fun." banner
+code.org##.mui-l611qg
+
+! Associated links under "Teachers" in the hotbar
+! - "AI Teaching Assistant"
+code.org##div.mui-12pwx0e:nth-of-type(2) > .mui-5i31c5 > li:nth-of-type(3)
+! - "AI Tutor"
+code.org##div.mui-12pwx0e:nth-of-type(2) > .mui-5i31c5 > li:nth-of-type(4)
+! - "Hour of AI"
+code.org##.mui-5i31c5 > li:nth-of-type(6)
+! - "Featured courses" widget, which currently contains only AI related items
+code.org##.mui-1xj8cq1
+
+! Associated links under "Advocacy" in the hotbar
+! - "TeachAI"
+code.org##div.mui-12pwx0e:nth-of-type(1) > .mui-5i31c5 > li:nth-of-type(2)
+! - "AI Literacy Framework"
+code.org##.mui-5i31c5 > li:nth-of-type(4)
+
+! -- https://code.org/parents
+! "Explore Hour of AI activites" button
+code.org##.cf-1f035385f689ecea8498db213245edbc
+! "Start with the Hour of AI" widget
+code.org##.mui-ralfbg.MuiBox-root.section-background-primary.section-root
+
 ! ================
 ! == Codecademy ==
 ! ================


### PR DESCRIPTION
Removes major AI widgets and associated links from CodeAI (formerly code.org). This does have many major changes, and might need more work but I feel that could be done in a seperate pull request. As I am not the most knowledgeable about filter lists, some of these filters might be fairly janky. If you require some clean-up or other changes, I would be happy to provide that as well. Thank you for your time. _PS: I apologize for the overwhelming amount of images, there is a lot of items to cover, and I wasn't sure if capturing all of the changes was required or not._

### Before:
<img width="1872" height="917" alt="image" src="https://github.com/user-attachments/assets/315100eb-8dbb-4e58-ad05-df356e97c086" />
<img width="1389" height="465" alt="image" src="https://github.com/user-attachments/assets/2b4d35fd-ae4e-4e8d-9179-711cacc19d9c" />
<img width="1213" height="346" alt="image" src="https://github.com/user-attachments/assets/cf79a78a-edfe-4c86-9eb0-151a5c73a13d" />
<img width="1053" height="882" alt="image" src="https://github.com/user-attachments/assets/cd0ed132-64aa-4b0d-ad59-cb924f0fa1f6" />
<img width="1133" height="780" alt="image" src="https://github.com/user-attachments/assets/7cd647bf-4062-4dd4-a091-f78c78efd2d9" />


### After:
<img width="1865" height="913" alt="image" src="https://github.com/user-attachments/assets/ffe450eb-8fac-4ea6-9644-ecb551b47420" />
<img width="1208" height="218" alt="image" src="https://github.com/user-attachments/assets/0320f21d-63fb-4fcb-82ec-9b5954af6c6f" />
<img width="1208" height="227" alt="image" src="https://github.com/user-attachments/assets/1a546b7b-c33a-4343-8af2-a6c0350d7112" />
<img width="1073" height="550" alt="image" src="https://github.com/user-attachments/assets/60d2022a-9a29-442f-9178-75ed8dd040bb" />
<img width="1047" height="449" alt="image" src="https://github.com/user-attachments/assets/e2af58ed-2932-4a5d-9a03-d48c21e258ca" />

